### PR TITLE
closes #102, update FAQ links

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -806,7 +806,7 @@
                         in 1990 to include areas along the Great Lakes, Puerto Rico, and the U.S. Virgin Islands. The three
                         purposes of this law are to minimize the loss of human life, conserve natural resources associated
                         with coastal barriers, and save taxpayers&#8217; dollars.
-                        <a href="https://www.fws.gov/cbra/Act.html"
+                        <a href="https://www.fws.gov/law/coastal-barrier-resources-act-1982 "
                             target="_blank"> Learn more</a>.
                     </div>
 
@@ -821,7 +821,7 @@
                         maps on file with the Secretary of the Interior entitled &#34;John H. Chafee Coastal Barrier Resources
                         System.&#34; The CBRS was renamed the &#34;John H. Chafee Coastal Barrier Resources System&#34; by
                         Pub. L. 106-167 in 1999 to honor the late Senator Chafee.
-                        <a href="https://www.fws.gov/cbra/Act.html#CBRS"
+                        <a href="https://www.fws.gov/law/coastal-barrier-resources-act-1982 "
                             target="_blank"> Learn more</a>.
                     </div>
 
@@ -871,7 +871,7 @@
                     </div>
                     <div class="faq-body" id="faq5body">
                         Section 4(a) of the
-                        <a href="https://www.fws.gov/cbra/Legislation.html#Act2005" target="_blank">2006 Coastal Barrier Resources Reauthorization Act (CBRRA) (Pub. L. 109-226)</a> directs the Secretary
+                        <a href="https://www.fws.gov/law/coastal-barrier-improvement-act-1990" target="_blank">2006 Coastal Barrier Resources Reauthorization Act (CBRRA) (Pub. L. 109-226)</a> directs the Secretary
                         of the Interior (Secretary) to prepare digital maps for the CBRS. Section 4(c)(3)(D) of the 2006
                         CBRRA directs the Secretary to make recommendations for the expansion of the CBRS when carrying out
                         the digital mapping.
@@ -893,7 +893,7 @@
                         of final recommended maps by the Service that take into consideration information provided during
                         the public comment period as well as the CBRA criteria and objective mapping protocols; and (5) Congressional
                         enactment of legislation to make the revised maps effective.
-                        <a href="https://www.fws.gov/cbra/maps/Map-Modernization.html"
+                        <a href="https://www.fws.gov/node/266092"
                             target="_blank"> Learn More</a>.
                     </div>
 
@@ -938,9 +938,7 @@
                     <div class="faq-body" id="faq9body">
                         The U.S. Fish & Wildlife Service (Service) has geospatial Coastal Barrier Resources System (CBRS) polygon data for the existing
                         and revised units available in a variety of formats. Please visit the
-                        <a href="https://www.fws.gov/cbra/maps/Boundaries.html" target="_blank"> Digital CBRS Boundaries</a> webpage for the existing CBRS boundary data. Please visit the
-                        <a href="https://www.fws.gov/cbra/maps/Map-Modernization.html"
-                            target="_blank"> Comprehensive Map Modernization</a> webpage for the revised CBRS boundary data.
+                        <a href="https://www.fws.gov/program/coastal-barrier-resources-act/maps-and-data" target="_blank"> Maps and Data</a> webpage for the existing CBRS boundary data.
                     </div>
 
                     <div class="faq-header" id="faq10header">10. Where can I get more information?

--- a/src/index.html
+++ b/src/index.html
@@ -841,7 +841,7 @@
                         in 1990 to include areas along the Great Lakes, Puerto Rico, and the U.S. Virgin Islands. The three
                         purposes of this law are to minimize the loss of human life, conserve natural resources associated
                         with coastal barriers, and save taxpayers&#8217; dollars.
-                        <a href="https://www.fws.gov/cbra/Act.html"
+                        <a href="https://www.fws.gov/law/coastal-barrier-resources-act-1982 "
                             target="_blank"> Learn more</a>.
                     </div>
 
@@ -856,7 +856,7 @@
                         maps on file with the Secretary of the Interior entitled &#34;John H. Chafee Coastal Barrier Resources
                         System.&#34; The CBRS was renamed the &#34;John H. Chafee Coastal Barrier Resources System&#34; by
                         Pub. L. 106-167 in 1999 to honor the late Senator Chafee.
-                        <a href="https://www.fws.gov/cbra/Act.html#CBRS"
+                        <a href="https://www.fws.gov/law/coastal-barrier-resources-act-1982 "
                             target="_blank"> Learn more</a>.
                     </div>
 
@@ -906,7 +906,7 @@
                     </div>
                     <div class="faq-body" id="faq5body">
                         Section 4(a) of the
-                        <a href="https://www.fws.gov/cbra/Legislation.html#Act2005" target="_blank">2006 Coastal Barrier Resources Reauthorization Act (CBRRA) (Pub. L. 109-226)</a> directs the Secretary
+                        <a href="https://www.fws.gov/law/coastal-barrier-improvement-act-1990" target="_blank">2006 Coastal Barrier Resources Reauthorization Act (CBRRA) (Pub. L. 109-226)</a> directs the Secretary
                         of the Interior (Secretary) to prepare digital maps for the CBRS. Section 4(c)(3)(D) of the 2006
                         CBRRA directs the Secretary to make recommendations for the expansion of the CBRS when carrying out
                         the digital mapping.
@@ -928,7 +928,7 @@
                         of final recommended maps by the Service that take into consideration information provided during
                         the public comment period as well as the CBRA criteria and objective mapping protocols; and (5) Congressional
                         enactment of legislation to make the revised maps effective.
-                        <a href="https://www.fws.gov/cbra/maps/Map-Modernization.html"
+                        <a href="https://www.fws.gov/node/266092"
                             target="_blank"> Learn More</a>.
                     </div>
 
@@ -973,9 +973,7 @@
                     <div class="faq-body" id="faq9body">
                         The U.S. Fish & Wildlife Service (Service) has geospatial Coastal Barrier Resources System (CBRS) polygon data for the existing
                         and revised units available in a variety of formats. Please visit the
-                        <a href="https://www.fws.gov/cbra/maps/Boundaries.html" target="_blank"> Digital CBRS Boundaries</a> webpage for the existing CBRS boundary data. Please visit the
-                        <a href="https://www.fws.gov/cbra/maps/Map-Modernization.html"
-                            target="_blank"> Comprehensive Map Modernization</a> webpage for the revised CBRS boundary data.
+                        <a href="https://www.fws.gov/program/coastal-barrier-resources-act/maps-and-data" target="_blank"> Maps and Data</a> webpage for the existing CBRS boundary data.
                     </div>
 
                     <div class="faq-header" id="faq10header">10. Where can I get more information?


### PR DESCRIPTION
I think this should be good to go according to [this doc.](https://doimspp.sharepoint.com/:w:/r/sites/GS-UMidWIMFWS-CBRS/_layouts/15/Doc.aspx?sourcedoc=%7B6B13CD70-79B6-45FF-85F1-E9FDE2E80932%7D&file=Project%20Mapper%20FAQ%20revisions.docx&action=edit&mobileredirect=true&wdPreviousSession=d5c7acd9-3de0-4b3c-ab3c-414825846cda&wdOrigin=TEAMS-ELECTRON.teams.undefined)

I updated the release notes to include issue #102, along with the prior website link updates (#99). Didn't think this change would need another release bump.  